### PR TITLE
Add mod-rewrite to php7 DockerFileWeb

### DIFF
--- a/build-lapp-7/DockerfileWeb
+++ b/build-lapp-7/DockerfileWeb
@@ -19,6 +19,7 @@ VOLUME ["/var/www/vhosts/myvhost"]
 VOLUME ["/var/www/vhosts/myvhost/private/deploy.php"]
 
 # install additional apache modules
+RUN a2enmod rewrite
 
 # install additional packages
 RUN apt-get update \


### PR DESCRIPTION
Enable of apache mod-rewrite ('RUN a2enmod rewrite') was present in php8 version of the build file, but not in this version.